### PR TITLE
Changes for shareDialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To use this plugin you will need to make sure you've registered your Facebook ap
 
 - [Web App Guide](platforms/web/README.md)
 
-- BlackBerry 10 - Under development
+- [BlackBerry 10] - (www/blackberry10/README.md)
 
 #### Example Apps
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To use this plugin you will need to make sure you've registered your Facebook ap
 
 - [Web App Guide](platforms/web/README.md)
 
-- [BlackBerry 10] - (www/blackberry10/README.md)
+- [BlackBerry 10 App Guide] (www/blackberry10/README.md)
 
 #### Example Apps
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -128,7 +128,7 @@
         <js-module src="www/blackberry10/facebookConnectPlugin.js" name="FacebookConnectPluginBB10" >
             <clobbers target="window.facebookConnectPluginBB10" />
         </js-module>
-		<dependency id='cordova-plugin-bb-invoke' url='.'/>
+		<dependency id='cordova-plugin-bb-invoke'/>
     </platform>
 
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -128,6 +128,7 @@
         <js-module src="www/blackberry10/facebookConnectPlugin.js" name="FacebookConnectPluginBB10" >
             <clobbers target="window.facebookConnectPluginBB10" />
         </js-module>
+		<dependency id='cordova-plugin-bb-invoke' url='.'/>
     </platform>
 
 

--- a/www/blackberry10/README.md
+++ b/www/blackberry10/README.md
@@ -46,26 +46,29 @@ For all API calls use `facebookConnectPluginBB10` instead of `facebookConnectPlu
 
 ###Login
 
-Any requests for permissions must be handled with login:
+Multiple permission requests are allowed and can only be added when calling Login.
+
+For example:
 ```
-facebookConnectPluginBB10.login(["user_friends", "email", "public_profile"],app.successHandler, app.errorHandler)
+facebookConnectPluginBB10.login(["user_friends", "email", "public_profile"], function(response) {console.log(response)},  function(response) {console.log(response)})
 ```
 
 For more information see: [Facebook Manual Login Documentation] (https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow)
 
 ###Get Status
 
-The most useful fields in `authResposne` are 'userID, accessToken and expiresIn'
-
-For more information see: [Facebook Manual Login Documentation] (https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow)
+Success function:
+Most useful fields are `authResposne` are `userID`, `accessToken`, and `expiresIn` this is the same for login success function as well
 
 ###Show a Dialog
 Send Dialog is not supported:  [Send Dialog Documentation](https://developers.facebook.com/docs/sharing/reference/send-dialog)
 
 ###The Graph API
-Permissions are handled strictly with Login, so permissions parameter should always be empty:
+Permissions are handled strictly with Login, so permissions parameter should always be `[]`.
+
+For example
 ```
-facebookConnectPluginBB10.api("me?fields=permissions", [],app.successHandler, app.errorHandler)
+facebookConnectPluginBB10.login("me", [], function(response) {console.log(response)},  function(response) {console.log(response)})
 ```
 ###Events:
 Not supported for Blackberry10 because there is no [API](https://developers.facebook.com/docs/app-events)

--- a/www/blackberry10/README.md
+++ b/www/blackberry10/README.md
@@ -36,27 +36,27 @@ You must change the `meta` tag for Content-Security-Policy in the `index.html` t
 
 1. Under **Client OAuth Settings** enable **WebOAuth Login**
 
-1. In the Valid **OAuth redirect URIs** add [https://www.facebook.com/connect/login_success.html]
+1. In the Valid **OAuth redirect URIs** add https://www.facebook.com/connect/login_success.html
 
 1. At bottom select **Save Changes**
 
-##Blackberry Notes
+##Blackberry 10 API Notes
 
-- Login
+###Login
+
 Any requests for permissions must be handled with login:
 ```
 facebookConnectPluginBB10.login(["user_friends", "email", "public_profile"],app.successHandler, app.errorHandler)
 ```
 
 For more information see: [Facebook Manual Login Documentation] (https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow)
-- Show a Dialog
-Send Dialog is not supported because of mobile limitation: [https://developers.facebook.com/docs/sharing/reference/send-dialog]
-- The Graph API
+###Show a Dialog
+Send Dialog is not supported because of [mobile limitation](https://developers.facebook.com/docs/sharing/reference/send-dialog)
+###The Graph API
 Permissions are handled strictly with Login, so parameter should always be empty:
 ```
 facebookConnectPluginBB10.api("me?fields=permissions", [],app.successHandler, app.errorHandler)
 ```
-
-- Events:
+###Events:
 Not supported for Blackberry10 because there is no [API](https://developers.facebook.com/docs/app-events)
 

--- a/www/blackberry10/README.md
+++ b/www/blackberry10/README.md
@@ -42,7 +42,7 @@ You must change the `meta` tag for Content-Security-Policy in the `index.html` t
 
 ##Blackberry 10 API Notes
 
-When calling the API use `facebookConnectPluginBB10` instead of `facebookConnectPlugin` for all API calls
+For all API calls use `facebookConnectPluginBB10` instead of `facebookConnectPlugin`
 
 ###Login
 
@@ -55,7 +55,7 @@ For more information see: [Facebook Manual Login Documentation] (https://develop
 
 ###Get Status
 
-The most useful fields in `authResposne` are userID, accessToken and expiresIn
+The most useful fields in `authResposne` are 'userID, accessToken and expiresIn'
 
 For more information see: [Facebook Manual Login Documentation] (https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow)
 

--- a/www/blackberry10/README.md
+++ b/www/blackberry10/README.md
@@ -14,10 +14,10 @@ To install the plugin in your app, execute the following (replace variables wher
 # Create initial Cordova app
 $ cordova create myApp
 $ cd myApp/
-$ cordova platform add browser
+$ cordova platform add blackberry10
 
 # Remember to replace APP_ID and APP_NAME variables
-$ cordova plugin add https://github.com/Wizcorp/phonegap-facebook-plugin/ --variable APP_ID="123456789" --variable APP_NAME="myApplication"
+$ cordova plugin add https://github.com/blackberry/phonegap-facebook-plugin --variable APP_ID="123456789" --variable APP_NAME="myApplication"
 ```
 
 ## Setup

--- a/www/blackberry10/README.md
+++ b/www/blackberry10/README.md
@@ -61,14 +61,14 @@ Success function:
 Most useful fields are `authResposne` are `userID`, `accessToken`, and `expiresIn` this is the same for login success function as well
 
 ###Show a Dialog
-Send Dialog is not supported:  [Send Dialog Documentation](https://developers.facebook.com/docs/sharing/reference/send-dialog)
+Send Dialog is not supported.  [Send Dialog Documentation](https://developers.facebook.com/docs/sharing/reference/send-dialog)
 
 ###The Graph API
 Permissions are handled strictly with Login, so permissions parameter should always be `[]`.
 
-For example
+For example:
 ```
-facebookConnectPluginBB10.login("me", [], function(response) {console.log(response)},  function(response) {console.log(response)})
+facebookConnectPluginBB10.api("me", [], function(response) {console.log(response)},  function(response) {console.log(response)})
 ```
 ###Events:
 Not supported for Blackberry10 because there is no [API](https://developers.facebook.com/docs/app-events)

--- a/www/blackberry10/README.md
+++ b/www/blackberry10/README.md
@@ -22,14 +22,14 @@ $ cordova plugin add https://github.com/Wizcorp/phonegap-facebook-plugin/ --vari
 
 ## Setup
 
-- You must change the Content-Security-Policy  in your project `index.html` to look like this:
+###Content Security Policy Configuration: 
+You must change the `meta` tag for Content-Security-Policy in the `index.html` to look like this:
 
 ```html
 <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *; connect-src local: 'self' http://localhost:8472 https://graph.facebook.com/" >
 ```
 
-- In your facebook application 
-
+###Facebook Application Configuration:
 1. Select **Settings**
 
 1. Select **Advanced**
@@ -42,24 +42,21 @@ $ cordova plugin add https://github.com/Wizcorp/phonegap-facebook-plugin/ --vari
 
 ##Blackberry Notes
 
--Login
+- Login
 Any requests for permissions must be handled with login:
-
-'''
+```
 facebookConnectPluginBB10.login(["user_friends", "email", "public_profile"],app.successHandler, app.errorHandler)
-'''
+```
 
-For more information see: [https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow]
--Get Login Status:
-
-For more information refer to
-
--Show a Dialog
+For more information see: [Facebook Manual Login Documentation] (https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow)
+- Show a Dialog
 Send Dialog is not supported because of mobile limitation: [https://developers.facebook.com/docs/sharing/reference/send-dialog]
--The Graph API
+- The Graph API
 Permissions are handled strictly with Login, so parameter should always be empty:
-'''
+```
 facebookConnectPluginBB10.api("me?fields=permissions", [],app.successHandler, app.errorHandler)
-'''
--Events:
-Not supported because it is only supported by Android and iOS platforms
+```
+
+- Events:
+Not supported for Blackberry10 because there is no [API](https://developers.facebook.com/docs/app-events)
+

--- a/www/blackberry10/README.md
+++ b/www/blackberry10/README.md
@@ -2,7 +2,7 @@
 
 To use this plugin you will need to make sure you've registered your Facebook app with Facebook and have an `APP_ID` [https://developers.facebook.com/apps](https://developers.facebook.com/apps).
 
-This plugin was built from a Micro-Library for facebook [https://github.com/ccoenraets/OpenFB]
+This plugin was built from a Micro-Library for facebook called [openFB] (https://github.com/ccoenraets/OpenFB)
 
 ## Install
 

--- a/www/blackberry10/README.md
+++ b/www/blackberry10/README.md
@@ -42,6 +42,8 @@ You must change the `meta` tag for Content-Security-Policy in the `index.html` t
 
 ##Blackberry 10 API Notes
 
+When calling the API use `facebookConnectPluginBB10` instead of `facebookConnectPlugin` for all API calls
+
 ###Login
 
 Any requests for permissions must be handled with login:
@@ -50,10 +52,18 @@ facebookConnectPluginBB10.login(["user_friends", "email", "public_profile"],app.
 ```
 
 For more information see: [Facebook Manual Login Documentation] (https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow)
+
+###Get Status
+
+The most useful fields are `authResposne` are userID, accessToken and expiresIn
+
+For more information see: [Facebook Manual Login Documentation] (https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow)
+
 ###Show a Dialog
-Send Dialog is not supported because of [mobile limitation](https://developers.facebook.com/docs/sharing/reference/send-dialog)
+Send Dialog is not supported:  [Send Dialog Documentation](https://developers.facebook.com/docs/sharing/reference/send-dialog)
+
 ###The Graph API
-Permissions are handled strictly with Login, so parameter should always be empty:
+Permissions are handled strictly with Login, so permissions parameter should always be empty:
 ```
 facebookConnectPluginBB10.api("me?fields=permissions", [],app.successHandler, app.errorHandler)
 ```

--- a/www/blackberry10/README.md
+++ b/www/blackberry10/README.md
@@ -1,0 +1,65 @@
+# Facebook Requirements and Set-Up [Blackberry10]
+
+To use this plugin you will need to make sure you've registered your Facebook app with Facebook and have an `APP_ID` [https://developers.facebook.com/apps](https://developers.facebook.com/apps).
+
+This plugin was built from a Micro-Library for facebook [https://github.com/ccoenraets/OpenFB]
+
+## Install
+
+This plugin requires [Cordova CLI](http://cordova.apache.org/docs/en/4.0.0/guide_cli_index.md.html).
+
+To install the plugin in your app, execute the following (replace variables where necessary):
+
+```sh
+# Create initial Cordova app
+$ cordova create myApp
+$ cd myApp/
+$ cordova platform add browser
+
+# Remember to replace APP_ID and APP_NAME variables
+$ cordova plugin add https://github.com/Wizcorp/phonegap-facebook-plugin/ --variable APP_ID="123456789" --variable APP_NAME="myApplication"
+```
+
+## Setup
+
+- You must change the Content-Security-Policy  in your project `index.html` to look like this:
+
+```html
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *; connect-src local: 'self' http://localhost:8472 https://graph.facebook.com/" >
+```
+
+- In your facebook application 
+
+1. Select **Settings**
+
+1. Select **Advanced**
+
+1. Under **Client OAuth Settings** enable **WebOAuth Login**
+
+1. In the Valid **OAuth redirect URIs** add [https://www.facebook.com/connect/login_success.html]
+
+1. At bottom select **Save Changes**
+
+##Blackberry Notes
+
+-Login
+Any requests for permissions must be handled with login:
+
+'''
+facebookConnectPluginBB10.login(["user_friends", "email", "public_profile"],app.successHandler, app.errorHandler)
+'''
+
+For more information see: [https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow]
+-Get Login Status:
+
+For more information refer to
+
+-Show a Dialog
+Send Dialog is not supported because of mobile limitation: [https://developers.facebook.com/docs/sharing/reference/send-dialog]
+-The Graph API
+Permissions are handled strictly with Login, so parameter should always be empty:
+'''
+facebookConnectPluginBB10.api("me?fields=permissions", [],app.successHandler, app.errorHandler)
+'''
+-Events:
+Not supported because it is only supported by Android and iOS platforms

--- a/www/blackberry10/README.md
+++ b/www/blackberry10/README.md
@@ -55,7 +55,7 @@ For more information see: [Facebook Manual Login Documentation] (https://develop
 
 ###Get Status
 
-The most useful fields are `authResposne` are userID, accessToken and expiresIn
+The most useful fields in `authResposne` are userID, accessToken and expiresIn
 
 For more information see: [Facebook Manual Login Documentation] (https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow)
 

--- a/www/blackberry10/README.md
+++ b/www/blackberry10/README.md
@@ -2,7 +2,7 @@
 
 To use this plugin you will need to make sure you've registered your Facebook app with Facebook and have an `APP_ID` [https://developers.facebook.com/apps](https://developers.facebook.com/apps).
 
-This plugin was built from a Micro-Library for facebook called [openFB] (https://github.com/ccoenraets/OpenFB)
+This plugin was based on a Micro-Library for facebook called [openFB] (https://github.com/ccoenraets/OpenFB)
 
 ## Install
 

--- a/www/blackberry10/facebookConnectPlugin.js
+++ b/www/blackberry10/facebookConnectPlugin.js
@@ -47,87 +47,41 @@ var facebookConnectPluginBB10 = {
     },
 
     showDialog: function (options, s, f) {
-
         var dialogWindow;
-
+		var url = facebookConnectPluginBB10.FB_DIALOG_URL;
         // determine method chosen
-        if (options.method == "share") {
-             dialogWindow = window.open(facebookConnectPluginBB10.FB_DIALOG_URL + 'share?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup&href=' + options.link + '&redirect_uri=' + options.redirect_uri);
-            window.inter = setInterval(function() {
-                var result = checkRedirect(dialogWindow, options.redirect_uri);
-                if (result.status == 'success') {
-                    window.clearInterval(inter);
-                    dialogWindow.window.close();
-                }
-                if (result.status == 'error') {
-                    window.clearInterval(inter);
-                }
-
-                }, 1000);
-        } else if (options.method == "share_open_graph") {            
-            dialogWindow = window.open(facebookConnectPluginBB10.FB_DIALOG_URL + 'share_open_graph?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup&action_type=' + options.action_type + '&action_properties=' + options.action_properties + '&redirect_uri=' + options.redirect_uri);
-            window.inter = setInterval(function() {
-                var result = checkRedirect(dialogWindow, options.redirect_uri);
-                if (result.status == 'success') {
-                    window.clearInterval(inter)
-                    dialogWindow.window.close();
-                }
-                if (result.status == 'error') {
-                    window.clearInterval(inter);
-                }
-            }, 1000);
+		if(options.method == "feed") {	
+			url = url + 'feed?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup' + '&redirect_uri=' + options.redirect_uri;
+			url = url + initFeedParameters(options);
+        } else if (options.method == "share") {
+			url = url + 'share?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup&href=' + options.href + '&redirect_uri=' + options.redirect_uri;
+        } else if (options.method == "share_open_graph"){           
+            url = url + 'share_open_graph?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup&action_type=' + options.action_type + '&action_properties=' + options.action_properties + '&redirect_uri=' + options.redirect_uri;
         } else if (options.method == "apprequests") {
-            var url = facebookConnectPluginBB10.FB_DIALOG_URL + 'apprequests?app_id=' + facebookConnectPluginBB10.fbAppId + '&message=' + options.message + '&redirect_uri=' + options.redirect_uri;
-            // check if object_id is set
-            if (options.object_id) {
-                url = url + '&object_id=' + options.object_id;
-            }
-            // check if 'to' is set
-            if (options.to) {
-                url = url + '&to=' + options.to;
-            }
-            // check for action_type
-            if (options.action_type) {
-                url = url + '&action_type=' + options.action_type;
-            }   
-            // check for filters
-            if (options.filters) {
-                url = url + '&filters=' + options.filters;
-            }
-            // check for suggestions
-            if (options.suggestions) {
-                url = url + '&suggestions=' + options.suggestions;
-            }
-            // check for data
-            if (options.data) {
-                url = url + '&data=' + options.data;
-            }
-            // check for title 
-            if (options.title) {
-                url = url + '&title=' +options.title;
-            }
-
-            // open dialog
-            dialogWindow = window.open(url);
-            window.inter = setInterval(function() {
-                var result = checkRedirect(dialogWindow, options.redirect_uri);
-                if (result.status == 'success') {
-                    window.clearInterval(inter)
-                    dialogWindow.window.close();
-                }
-                if (result.status == 'error') {
-                    window.clearInterval(inter);
-                }
-            }, 1000);
-        } else {
+            url = url + 'apprequests?app_id=' + facebookConnectPluginBB10.fbAppId + '&message=' + options.message + '&redirect_uri=' + options.redirect_uri;
+			url = url + initAppRequestsParameters(options);
+		} else if (options.method == "send"){ //
+			url = url + 'send?app_id=' + facebookConnectPluginBB10.fbAppId + '&link=' + options.link + '&redirect_uri=' + options.redirect_uri;
+		} else {
                 // fail due to invalid method
-                alert('Invalid dialog method chosen.');
-                dialogStatus = {}
-                if (f) {
-                    dialogStatus.status = 'Invalid method';
-                    f(dialogStatus);
-                }
-        }
+            dialogStatus = {}
+            if (f) {
+                dialogStatus.status = 'Invalid method';
+                f(dialogStatus);
+            }
+		}
+		dialogWindow = window.open(url);
+		window.inter = setInterval(function(){
+			var result = checkRedirect(dialogWindow, options.redirect_uri);
+			if (result.status == 'success') {
+				window.clearInterval(inter);
+				dialogWindow.window.close();
+			}
+			if (result.status == 'error') {
+				window.clearInterval(inter);
+			}
+
+			}, 1000);
     },
 
     login: function (permissions, s, f) {
@@ -278,7 +232,76 @@ function checkRedirect(currentWindow, redirect_uri) {
         return {status: 'success'}
     } else {
         return {status: 'unknown'};
+
+function initAppRequestsParameters(options){
+// check if object_id is set
+	var parameterString = "";
+	if (options.object_id) {
+		parameterString = parameterString + '&object_id=' + options.object_id;
+	}
+	// check if 'to' is set
+	if (options.to) {
+		parameterString = parameterString + '&to=' + options.to;
+	}
+	// check for action_type
+	if (options.action_type) {
+		parameterString = parameterString + '&action_type=' + options.action_type;
+	}   
+	// check for filters
+	if (options.filters) {
+		parameterString = parameterString + '&filters=' + options.filters;
+	}
+	// check for suggestions
+	if (options.suggestions) {
+		parameterString = parameterString + '&suggestions=' + options.suggestions;
+	}
+            // check for data
+    if (options.data) {
+		parameterString = parameterString + '&data=' + options.data;
     }
+    // check for title 
+    if (options.title) {
+        parameterString = parameterString + '&title=' +options.title;
+    }
+	return parameterString
 }
 
+function initFeedParameters(options){
+	var parameterString = "";
+	// check if 'to' is set
+	if (options.to) {
+		parameterString = parameterString + '&to=' + options.to;
+	}
+	if (options.from) {
+		parameterstring = parameterString + '&from' + options.from;
+	}
+    // check for link
+    if (options.link) {
+		parameterString = parameterString + '&link=' + options.link;
+    }
+    // check for picture 
+    if (options.picture) {
+        parameterString = parameterString + '&picture=' +options.picture;
+    }
+	// check for source 
+    if (options.source) {
+        parameterString = parameterString + '&source=' +options.source;
+    }
+	// check for name
+	if(options.name) {
+		parameterString = parameterString + '&name=' + options.name;
+	}
+	// check for caption
+	if(options.caption) {
+		parameterString = parameterString + '&caption=' + options.caption;
+	}
+	// check for name
+	if(options.description) {
+		parameterString = parameterString + '&description=' + options.description;
+	}
+	if(options.ref) {
+		parameterString = parameterString + '&ref=' + options.ref;
+	}
+	return parameterString;
+}
 module.exports = facebookConnectPluginBB10;

--- a/www/blackberry10/facebookConnectPlugin.js
+++ b/www/blackberry10/facebookConnectPlugin.js
@@ -158,7 +158,15 @@ var facebookConnectPluginBB10 = {
         url = url + '&scope=' + scope;
         loginWindow = window.open(url, '_blank');
         window.inter = setInterval(function() {
-            var currentURL = loginWindow.window.location.href;
+            var currentURL = "";
+            try{
+                currentURL = loginWindow.window.location.href;
+            }catch(error){
+                    if(f){
+                        f("User cancelled dialog");
+                    }
+                    window.clearInterval(inter);
+            }
             var callbackURL = redirectUri;
             var inCallback = currentURL.indexOf("access_token=");
             var hasError = currentURL.indexOf("error_code=");

--- a/www/blackberry10/facebookConnectPlugin.js
+++ b/www/blackberry10/facebookConnectPlugin.js
@@ -221,17 +221,23 @@ function toQueryString(obj) {
 }
 
 function checkRedirect(currentWindow, redirect_uri) {
-    var currentURL = currentWindow.window.location.href;
-    var hasError = currentURL.indexOf('error_code');
-    var inRedirect = currentURL.indexOf(redirect_uri);
+	try {
+		var currentURL = currentWindow.window.location.href;
+		var hasError = currentURL.indexOf('error_code');
+		var inRedirect = currentURL.indexOf(redirect_uri);
 
-    // if (hasError != -1) {
-    if (currentWindow.window.document.title == "Error") {
-        return {status: 'error'};
-    } else if (inRedirect == 0) {
-        return {status: 'success'}
-    } else {
-        return {status: 'unknown'};
+		// if (hasError != -1) {
+		if (currentWindow.window.document.title == "Error") {
+			return {status: 'error'};
+		} else if (inRedirect == 0) {
+			return {status: 'success'}
+		} else {
+			return {status: 'unknown'};
+		}
+	} catch (error) {
+		return {status: 'error'}; 
+	}
+}
 
 function initAppRequestsParameters(options){
 // check if object_id is set

--- a/www/blackberry10/facebookConnectPlugin.js
+++ b/www/blackberry10/facebookConnectPlugin.js
@@ -34,21 +34,21 @@ var facebookConnectPluginBB10 = {
 
     getLoginStatus: function (s, f) {
         var token = facebookConnectPluginBB10.tokenStore['access_token'],
-		expires_in = facebookConnectPluginBB10.tokenStore['expires_in'],
+        expires_in = facebookConnectPluginBB10.tokenStore['expires_in'],
         loginStatus = {};
         if (token) {
-			facebookConnectPluginBB10.api("me",[], function(response){
-				loginStatus.status = 'connected';
-				loginStatus.authResponse = {
-					userID:response.id,
-					accessToken: token,
-					session_Key: true,
-					expiresIn: expires_in,
-					sig: "..."
-				}
-				if (s) s(loginStatus);
-				return;
-			}, f);
+            facebookConnectPluginBB10.api("me",[], function(response){
+                loginStatus.status = 'connected';
+                loginStatus.authResponse = {
+                    userID:response.id,
+                    accessToken: token,
+                    session_Key: true,
+                    expiresIn: expires_in,
+                    sig: "..."
+                }
+                if (s) s(loginStatus);
+                return;
+            }, f);
         } else {
             loginStatus.status = 'unknown';
             if (f) f(loginStatus);
@@ -58,80 +58,80 @@ var facebookConnectPluginBB10 = {
 
     showDialog: function (options, s, f) {
         var dialogWindow;
-		var url = facebookConnectPluginBB10.FB_DIALOG_URL;
-		options.redirect_uri = "https://m.facebook.com";
+        var url = facebookConnectPluginBB10.FB_DIALOG_URL;
+        options.redirect_uri = "https://m.facebook.com";
         // determine method chosen
-		if(options.method == "feed") {	
-			url = url + 'feed?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup' + '&redirect_uri=' + options.redirect_uri;
-			url = url + initFeedParameters(options);
+        if(options.method == "feed") {    
+            url = url + 'feed?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup' + '&redirect_uri=' + options.redirect_uri;
+            url = url + initFeedParameters(options);
         } else if (options.method == "share") {
-			if(!options.href){
-				blackberry.invoke.invoke({
-				target: "Facebook",
-				action: "bb.action.SHARE",
-				type: "text/plain",
-				data: " "
-				}, s, f);
-				return;
-			}
-			url = url + 'share?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup&href=' + options.href + '&redirect_uri=' + options.redirect_uri;
+            if(!options.href){
+                blackberry.invoke.invoke({
+                target: "Facebook",
+                action: "bb.action.SHARE",
+                type: "text/plain",
+                data: " "
+                }, s, f);
+                return;
+            }
+            url = url + 'share?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup&href=' + options.href + '&redirect_uri=' + options.redirect_uri;
         } else if (options.method == "share_open_graph"){  
-			if(!options.action_type && !options.action_properties) {
-				blackberry.invoke.invoke({
-						target: "Facebook",
-						action: "bb.action.SHARE",
-						type: "text/plain",
-						data: " "
-					}, s, f);
-				return;
-			}
+            if(!options.action_type && !options.action_properties) {
+                blackberry.invoke.invoke({
+                        target: "Facebook",
+                        action: "bb.action.SHARE",
+                        type: "text/plain",
+                        data: " "
+                    }, s, f);
+                return;
+            }
             url = url + 'share_open_graph?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup&action_type=' + options.action_type + '&action_properties=' + options.action_properties + '&redirect_uri=' + options.redirect_uri;
         } else if (options.method == "apprequests") {
             url = url + 'apprequests?app_id=' + facebookConnectPluginBB10.fbAppId + '&message=' + options.message + '&redirect_uri=' + options.redirect_uri;
-			url = url + initAppRequestsParameters(options);
-		} /*else if (options.method == "send"){ 
-			blackberry.invoke.invoke({
-						target: "Facebook",
-						action: "bb.action.COMPOSE", 
-						type: "Facebook/message",
-						data: "hello"
-					}, s, f);
-			return;
-		} */else {
+            url = url + initAppRequestsParameters(options);
+        } /*else if (options.method == "send"){ 
+            blackberry.invoke.invoke({
+                        target: "Facebook",
+                        action: "bb.action.COMPOSE", 
+                        type: "Facebook/message",
+                        data: "hello"
+                    }, s, f);
+            return;
+        } */else {
             // fail due to invalid method
             dialogStatus = {}
             if (f) {
                 dialogStatus.status = 'Invalid method';
                 f(dialogStatus);
-				return;
+                return;
             }
-		}
-		dialogWindow = window.open(url);
-		window.inter = setInterval(function(){
+        }
+        dialogWindow = window.open(url);
+        window.inter = setInterval(function(){
             var result = checkRedirect(dialogWindow, options.redirect_uri);
-			if (result.status == 'success') {
-				window.clearInterval(inter);
-				if(s && result.response){
-					s(ParseDialogResponse(result.response, options.method));
-				}
-				dialogWindow.window.close();
-			}
-			if (result.status == 'error') {
-				window.clearInterval(inter);
-				if(f && result.errorMessage){
-					f(result.errorMessage);
-				}
-			}
-			if (result.status == 'error_code'){
-				//Parse out error 
-				if(f && result.response){
-					f(ParseDialogError(result.response));
-				}
-				window.clearInterval(inter);
-				dialogWindow.window.close();
-			}
+            if (result.status == 'success') {
+                window.clearInterval(inter);
+                if(s && result.response){
+                    s(ParseDialogResponse(result.response, options.method));
+                }
+                dialogWindow.window.close();
+            }
+            if (result.status == 'error') {
+                window.clearInterval(inter);
+                if(f && result.errorMessage){
+                    f(result.errorMessage);
+                }
+            }
+            if (result.status == 'error_code'){
+                //Parse out error 
+                if(f && result.response){
+                    f(ParseDialogError(result.response));
+                }
+                window.clearInterval(inter);
+                dialogWindow.window.close();
+            }
 
-			}, 1000);
+            }, 1000);
     },
 
     login: function (permissions, s, f) {
@@ -152,26 +152,26 @@ var facebookConnectPluginBB10 = {
         startTime = new Date().getTime();
         redirectUri = facebookConnectPluginBB10.FB_LOGIN_URL + '?client_id=' + facebookConnectPluginBB10.fbAppId + '&redirect_uri=' + oauthRedirectURL +
             '&response_type=token&scope=' + scope;
-		//Wow, look how much more readable that is.
-		var url = 'https://www.facebook.com/dialog/oauth?client_id=' + facebookConnectPluginBB10.fbAppId;
-		url = url + '&redirect_uri=https://www.facebook.com/connect/login_success.html&response_type=token&auth_type=rerequest';
-		url = url + '&scope=' + scope;
+        //Wow, look how much more readable that is.
+        var url = 'https://www.facebook.com/dialog/oauth?client_id=' + facebookConnectPluginBB10.fbAppId;
+        url = url + '&redirect_uri=https://www.facebook.com/connect/login_success.html&response_type=token&auth_type=rerequest';
+        url = url + '&scope=' + scope;
         loginWindow = window.open(url, '_blank');
         window.inter = setInterval(function() {
             var currentURL = loginWindow.window.location.href;
             var callbackURL = redirectUri;
             var inCallback = currentURL.indexOf("access_token=");
-			var hasError = currentURL.indexOf("error_code=");
+            var hasError = currentURL.indexOf("error_code=");
 
             // location has changed to our callback url
             if(hasError >= 0){
-				if(f){
-					f(ParseDialogError(currentURL))	
-				}
-				window.clearInterval(inter);
-				loginWindow.window.close();
-				return; 
-			} else if (inCallback != -1) {
+                if(f){
+                    f(ParseDialogError(currentURL))    
+                }
+                window.clearInterval(inter);
+                loginWindow.window.close();
+                return; 
+            } else if (inCallback != -1) {
 
                 // stop the interval
                 window.clearInterval(inter);
@@ -181,25 +181,25 @@ var facebookConnectPluginBB10 = {
                 code = code.split('access_token=');
                 code = code[1];
                 code = code.split('&expires_in=');
-				access_token = code[0];
-				expires_In = code[1];
-				//expires_In = parseInt(code[1]);
+                access_token = code[0];
+                expires_In = code[1];
+                //expires_In = parseInt(code[1]);
                 facebookConnectPluginBB10.tokenStore.access_token = access_token;
-				facebookConnectPluginBB10.tokenStore.expires_in = expires_In;
+                facebookConnectPluginBB10.tokenStore.expires_in = expires_In;
                 // close the loginWindow
                 loginWindow.window.close();
                 facebookConnectPluginBB10.api("me",[], function(response){
-				s({
-					status: 'connected',
-					authResponse: {
-							accessToken: access_token,
-							expiresIn: expires_In,
-							session_key: true,
-							sig: "...",
-							secret: "...",
-							userId: response.id
-					}
-				})}, f);
+                s({
+                    status: 'connected',
+                    authResponse: {
+                            accessToken: access_token,
+                            expiresIn: expires_In,
+                            session_key: true,
+                            sig: "...",
+                            secret: "...",
+                            userId: response.id
+                    }
+                })}, f);
             }
         }, 1000);
     },
@@ -217,26 +217,26 @@ var facebookConnectPluginBB10 = {
     logout: function (s, f) {
         var logoutWindow,
         token = facebookConnectPluginBB10.tokenStore['access_token'];
-		loggedOut = false;
+        loggedOut = false;
         if (token) {
-			loggedOut = true;
+            loggedOut = true;
             facebookConnectPluginBB10.tokenStore.removeItem('access_token');
-			facebookConnectPluginBB10.tokenStore.removeItem('expires_in');
-			var logoutRedirectURL = "https://www.facebook.com/";
+            facebookConnectPluginBB10.tokenStore.removeItem('expires_in');
+            var logoutRedirectURL = "https://www.facebook.com/";
             logoutWindow = window.open(facebookConnectPluginBB10.FB_LOGOUT_URL + '?access_token=' + token + '&next=' + logoutRedirectURL, '_blank', 'location=no');
-			var runningInCordova = !!window.cordova;
-			if (runningInCordova) {
+            var runningInCordova = !!window.cordova;
+            if (runningInCordova) {
                 setTimeout(function() {
                     logoutWindow.close();
                 }, 1000);
             }
         } else if (f) {
-			f("Session not open");
-		}
-		
-		if(loggedOut && s) {
-			s("Ok");
-		}
+            f("Session not open");
+        }
+        
+        if(loggedOut && s) {
+            s("Ok");
+        }
     },
 
     api: function (graphPath, permissions, s, f) {
@@ -296,148 +296,148 @@ function toQueryString(obj) {
 }
 
 function checkRedirect(currentWindow, redirect_uri) {
-	try {
-		var currentURL = currentWindow.window.location.href;
-		var hasError = currentURL.indexOf('error_code');
-		var redirectUriLength = redirect_uri.length;
-		var inRedirect = currentURL.indexOf("app_");
-		if (hasError >= 0){
-			return {status:'error_code', response: currentURL};
-		} else
-		if (currentWindow.window.document.title == "Error") {
-			return {status: 'error', errorMessage: "An error occurred during request"};
-		}  else if (inRedirect == -1 && currentURL != 'about:blank') {
-			return {status: 'success', response: currentURL};
-		} else {
-			return {status: 'unknown'};
-		}
-	} catch (error) {
+    try {
+        var currentURL = currentWindow.window.location.href;
+        var hasError = currentURL.indexOf('error_code');
+        var redirectUriLength = redirect_uri.length;
+        var inRedirect = currentURL.indexOf("app_");
+        if (hasError >= 0){
+            return {status:'error_code', response: currentURL};
+        } else
+        if (currentWindow.window.document.title == "Error") {
+            return {status: 'error', errorMessage: "An error occurred during request"};
+        }  else if (inRedirect == -1 && currentURL != 'about:blank') {
+            return {status: 'success', response: currentURL};
+        } else {
+            return {status: 'unknown'};
+        }
+    } catch (error) {
         return {status: 'error', errorMessage: "User cancelled dialog"}; 
-	}
+    }
 }
 
 function initAppRequestsParameters(options){
 // check if object_id is set
-	var parameterString = "";
-	if (options.object_id) {
-		parameterString = parameterString + '&object_id=' + options.object_id;
-	}
-	// check if 'to' is set
-	if (options.to) {
-		parameterString = parameterString + '&to=' + options.to;
-	}
-	// check for action_type
-	if (options.action_type) {
-		parameterString = parameterString + '&action_type=' + options.action_type;
-	}   
-	// check for filters
-	if (options.filters) {
-		parameterString = parameterString + '&filters=' + options.filters;
-	}
-	// check for suggestions
-	if (options.suggestions) {
-		parameterString = parameterString + '&suggestions=' + options.suggestions;
-	}
+    var parameterString = "";
+    if (options.object_id) {
+        parameterString = parameterString + '&object_id=' + options.object_id;
+    }
+    // check if 'to' is set
+    if (options.to) {
+        parameterString = parameterString + '&to=' + options.to;
+    }
+    // check for action_type
+    if (options.action_type) {
+        parameterString = parameterString + '&action_type=' + options.action_type;
+    }   
+    // check for filters
+    if (options.filters) {
+        parameterString = parameterString + '&filters=' + options.filters;
+    }
+    // check for suggestions
+    if (options.suggestions) {
+        parameterString = parameterString + '&suggestions=' + options.suggestions;
+    }
             // check for data
     if (options.data) {
-		parameterString = parameterString + '&data=' + options.data;
+        parameterString = parameterString + '&data=' + options.data;
     }
     // check for title 
     if (options.title) {
         parameterString = parameterString + '&title=' +options.title;
     }
-	return parameterString
+    return parameterString
 }
 
 function initFeedParameters(options){
-	var parameterString = "";
-	// check if 'to' is set
-	if (options.to) {
-		parameterString = parameterString + '&to=' + options.to;
-	}
-	if (options.from) {
-		parameterstring = parameterString + '&from' + options.from;
-	}
+    var parameterString = "";
+    // check if 'to' is set
+    if (options.to) {
+        parameterString = parameterString + '&to=' + options.to;
+    }
+    if (options.from) {
+        parameterstring = parameterString + '&from' + options.from;
+    }
     // check for link
     if (options.link) {
-		parameterString = parameterString + '&link=' + options.link;
+        parameterString = parameterString + '&link=' + options.link;
     }
     // check for picture 
     if (options.picture) {
         parameterString = parameterString + '&picture=' +options.picture;
     }
-	// check for source 
+    // check for source 
     if (options.source) {
         parameterString = parameterString + '&source=' +options.source;
     }
-	// check for name
-	if(options.name) {
-		parameterString = parameterString + '&name=' + options.name;
-	}
-	// check for caption
-	if(options.caption) {
-		parameterString = parameterString + '&caption=' + options.caption;
-	}
-	// check for name
-	if(options.description) {
-		parameterString = parameterString + '&description=' + options.description;
-	}
-	if(options.ref) {
-		parameterString = parameterString + '&ref=' + options.ref;
-	}
-	return parameterString;
+    // check for name
+    if(options.name) {
+        parameterString = parameterString + '&name=' + options.name;
+    }
+    // check for caption
+    if(options.caption) {
+        parameterString = parameterString + '&caption=' + options.caption;
+    }
+    // check for name
+    if(options.description) {
+        parameterString = parameterString + '&description=' + options.description;
+    }
+    if(options.ref) {
+        parameterString = parameterString + '&ref=' + options.ref;
+    }
+    return parameterString;
 }
 
 function ParseDialogResponse(response, method){
-	var ret = {};
-	if(CheckForPostID(response, method)){
-		var stringParts = response.split("post_id=");
-		var postId = "";
-		if(response.length >= 2){
-			postId = stringParts[1];
-			postId = postId.split("#_=_")[0];
-		}	
-		ret.post_id = postId;
-	} else if (method == "apprequests" && response.indexOf("to") >= 0){
-		var raw = response.split("?")[1];
-		raw = raw.split("request=")[1];
-		raw = raw.split("#_=_")[0];
-		raw = raw.split("&");
-		var numbers = [];
-		numbers.push(raw[0]);
-		for (var i = 1; i < raw.length; i++){
-			numbers.push(raw[i].split("=")[1]);
-		}
-		ret.request = numbers[0];
-		ret.to = []
-		
-		for (var i = 1; i < numbers.length; i++){
-			ret.to.push(numbers[i]);
-		}
-	}
-	return ret;
+    var ret = {};
+    if(CheckForPostID(response, method)){
+        var stringParts = response.split("post_id=");
+        var postId = "";
+        if(response.length >= 2){
+            postId = stringParts[1];
+            postId = postId.split("#_=_")[0];
+        }    
+        ret.post_id = postId;
+    } else if (method == "apprequests" && response.indexOf("to") >= 0){
+        var raw = response.split("?")[1];
+        raw = raw.split("request=")[1];
+        raw = raw.split("#_=_")[0];
+        raw = raw.split("&");
+        var numbers = [];
+        numbers.push(raw[0]);
+        for (var i = 1; i < raw.length; i++){
+            numbers.push(raw[i].split("=")[1]);
+        }
+        ret.request = numbers[0];
+        ret.to = []
+        
+        for (var i = 1; i < numbers.length; i++){
+            ret.to.push(numbers[i]);
+        }
+    }
+    return ret;
 }
 function CheckForPostID(response, method){
-	var methods = ["feed", "share", "share_open_graph"];
-	if(response.indexOf("post_id") == -1){
-		return false;
-	}
-	for (var i = 0; i < methods.length; i++){
-		if(methods[i] == method){
-			return true;
-		}
-	}
-	return false;
+    var methods = ["feed", "share", "share_open_graph"];
+    if(response.indexOf("post_id") == -1){
+        return false;
+    }
+    for (var i = 0; i < methods.length; i++){
+        if(methods[i] == method){
+            return true;
+        }
+    }
+    return false;
 }
 
 function ParseDialogError(response){
-	var ret = {};
-	var raw = response.split("?")[1];
-	raw = raw.split("#_=_")[0];
-	raw = raw.split("&");
-	ret.error_code = raw[0].split("error_code=")[1];
-	ret.error_message = raw[1].split("error_message=")[1];
-	return ret;
+    var ret = {};
+    var raw = response.split("?")[1];
+    raw = raw.split("#_=_")[0];
+    raw = raw.split("&");
+    ret.error_code = raw[0].split("error_code=")[1];
+    ret.error_message = raw[1].split("error_message=")[1];
+    return ret;
 }
 
 

--- a/www/blackberry10/facebookConnectPlugin.js
+++ b/www/blackberry10/facebookConnectPlugin.js
@@ -54,8 +54,26 @@ var facebookConnectPluginBB10 = {
 			url = url + 'feed?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup' + '&redirect_uri=' + options.redirect_uri;
 			url = url + initFeedParameters(options);
         } else if (options.method == "share") {
+			if(!options.href){
+				blackberry.invoke.invoke({
+				target: "Facebook",
+				action: "bb.action.SHARE",
+				type: "text/plain",
+				data: " "
+				}, s, f);
+				return;
+			}
 			url = url + 'share?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup&href=' + options.href + '&redirect_uri=' + options.redirect_uri;
-        } else if (options.method == "share_open_graph"){           
+        } else if (options.method == "share_open_graph"){  
+			if(!options.action_type && !options.action_properties) {
+				blackberry.invoke.invoke({
+						target: "Facebook",
+						action: "bb.action.SHARE",
+						type: "text/plain",
+						data: " "
+					}, s, f);
+				return;
+			}
             url = url + 'share_open_graph?app_id=' + facebookConnectPluginBB10.fbAppId + '&display=popup&action_type=' + options.action_type + '&action_properties=' + options.action_properties + '&redirect_uri=' + options.redirect_uri;
         } else if (options.method == "apprequests") {
             url = url + 'apprequests?app_id=' + facebookConnectPluginBB10.fbAppId + '&message=' + options.message + '&redirect_uri=' + options.redirect_uri;


### PR DESCRIPTION
After a lot of work, I've changed the shoDialog to mimic the android version as much as possible, although there are some differences on case specific things:
- In the event you try to send 2 message to the feed but get an API error, the error message is different and the window does not close automatically, I could change this if preferred.
- The error parsing is rather... "raw" all it does it get the information after the 2 parameters but doesn't clean them up in anyways. The possible "issue" with this is then the error message contains a lot of facebook jibberish between words
  -When the invoke stuff is used, the response data is not obtained. That's just the nature of it
  -Send is not implemented, but left it just as a reminder that theoretically it is pausible. I tried several different scenarios, including the suggestion about removing data from the invoke call. The usual result is that if using the type:"facebook/message" in any capacity, the screen just goes white. My theory is it is actually trying to open up a specific BB10 facebook messenger app, that if it cannot find will not open. When I tried to download one, the "official" one I found cost money so I didn't test this, but perhaps it is something to try
  -The initialize fields methods use lots of if statements because the expected behavior is that these fields are the only valid ones available and if you try using other ones an error will occur ( not desired)
